### PR TITLE
03 system spec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,11 +12,18 @@ gem 'coffee-rails', '~> 4.2'
 gem 'bootsnap', '>= 1.1.0', require: false
 gem 'sorcery'
 
+
 group :development, :test do
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
   gem 'rspec-rails', '~> 4.0.2'
   gem 'factory_bot_rails'
 end
+
+group :test do
+  gem 'capybara'
+  gem 'webdrivers'
+end
+
 
 group :development do
   gem 'web-console', '>= 3.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,6 +42,8 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     arel (9.0.0)
     ast (2.4.0)
     bcrypt (3.1.13)
@@ -56,6 +58,15 @@ GEM
       msgpack (~> 1.0)
     builder (3.2.3)
     byebug (11.0.1)
+    capybara (3.35.1)
+      addressable
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (>= 1.5, < 3.0)
+      xpath (~> 3.2)
+    childprocess (3.0.0)
     code_analyzer (0.4.8)
       sexp_processor
     coderay (1.1.2)
@@ -132,6 +143,7 @@ GEM
       yard (~> 0.9.11)
     pry-rails (0.3.9)
       pry (>= 0.10.4)
+    public_suffix (4.0.6)
     puma (3.12.6)
     rack (2.2.2)
     rack-test (1.1.0)
@@ -173,6 +185,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
+    regexp_parser (2.0.3)
     require_all (2.0.0)
     rspec-core (3.10.1)
       rspec-support (~> 3.10.0)
@@ -200,6 +213,7 @@ GEM
       unicode-display_width (>= 1.4.0, < 1.7)
     ruby-progressbar (1.10.1)
     ruby_dep (1.5.0)
+    rubyzip (2.3.0)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -211,6 +225,9 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    selenium-webdriver (3.142.7)
+      childprocess (>= 0.5, < 4.0)
+      rubyzip (>= 1.2.2)
     sexp_processor (4.13.0)
     sorcery (0.15.0)
       bcrypt (~> 3.1)
@@ -241,9 +258,15 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
+    webdrivers (4.5.0)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (>= 3.0, < 4.0)
     websocket-driver (0.7.1)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.4)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
     yard (0.9.20)
 
 PLATFORMS
@@ -254,6 +277,7 @@ DEPENDENCIES
   binding_of_caller
   bootsnap (>= 1.1.0)
   byebug
+  capybara
   coffee-rails (~> 4.2)
   factory_bot_rails
   listen (>= 3.0.5, < 3.2)
@@ -273,6 +297,7 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
+  webdrivers
 
 RUBY VERSION
    ruby 2.6.4p104

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -2,42 +2,42 @@ require 'rails_helper'
 
 RSpec.describe Task, type: :model do
   # pending "add some examples to (or delete) #{__FILE__}"
-  # describe 'validates' do
-  #   it '有効であること' do
-  #     # user = FactoryBot.create(:user)
-  #     task = build(:task)
-  #     expect(task).to be_valid
-  #     expect(task.errors).to be_empty
-  #   end
-  #   it 'タイトルが無ければ無効であること' do
-  #     # user = FactoryBot.create(:user)
+  describe 'validates' do
+    it '有効であること' do
+      # user = FactoryBot.create(:user)
+      task = build(:task)
+      expect(task).to be_valid
+      expect(task.errors).to be_empty
+    end
+    it 'タイトルが無ければ無効であること' do
+      # user = FactoryBot.create(:user)
 
-  #     task_without_title = build(:task, title: nil)
-  #     expect(task_without_title).to be_invalid
-  #     expect(task_without_title.errors[:title]).to include("can't be blank")
-  #   end
-  #   it 'ステータスが無ければ無効であること' do
-  #     # user = FactoryBot.create(:user)
+      task_without_title = build(:task, title: nil)
+      expect(task_without_title).to be_invalid
+      expect(task_without_title.errors[:title]).to include("can't be blank")
+    end
+    it 'ステータスが無ければ無効であること' do
+      # user = FactoryBot.create(:user)
 
-  #     task_without_status = build(:task, status: nil)
-  #     expect(task_without_status).to be_invalid
-  #     expect(task_without_status.errors[:status]).to include("can't be blank")
-  #   end
-  #   it 'タイトルが一意でなければ無効な状態であること' do
-  #     # user = FactoryBot.create(:user)
+      task_without_status = build(:task, status: nil)
+      expect(task_without_status).to be_invalid
+      expect(task_without_status.errors[:status]).to include("can't be blank")
+    end
+    it 'タイトルが一意でなければ無効な状態であること' do
+      # user = FactoryBot.create(:user)
 
-  #     task = create(:task)
-  #     task_with_duplicated_title = build(:task, title: task.title)
-  #     expect(task_with_duplicated_title).to be_invalid
-  #     expect(task_with_duplicated_title.errors[:title]).to include("has already been taken")
-  #   end
-  #   it 'タイトルが一意であれば有効であること' do
-  #     # user = FactoryBot.create(:user)
+      task = create(:task)
+      task_with_duplicated_title = build(:task, title: task.title)
+      expect(task_with_duplicated_title).to be_invalid
+      expect(task_with_duplicated_title.errors[:title]).to include("has already been taken")
+    end
+    it 'タイトルが一意であれば有効であること' do
+      # user = FactoryBot.create(:user)
 
-  #     task = create(:task)
-  #     task_with_another_title = build(:task, title: 'another_title')
-  #     expect(task_with_another_title).to be_valid
-  #     expect(task_with_another_title.errors).to be_empty
-  #   end
-  # end
+      task = create(:task)
+      task_with_another_title = build(:task, title: 'another_title')
+      expect(task_with_another_title).to be_valid
+      expect(task_with_another_title.errors).to be_empty
+    end
+  end
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -2,42 +2,42 @@ require 'rails_helper'
 
 RSpec.describe Task, type: :model do
   # pending "add some examples to (or delete) #{__FILE__}"
-  describe 'validates' do
-    it '有効であること' do
-      # user = FactoryBot.create(:user)
-      task = build(:task)
-      expect(task).to be_valid
-      expect(task.errors).to be_empty
-    end
-    it 'タイトルが無ければ無効であること' do
-      # user = FactoryBot.create(:user)
+  # describe 'validates' do
+  #   it '有効であること' do
+  #     # user = FactoryBot.create(:user)
+  #     task = build(:task)
+  #     expect(task).to be_valid
+  #     expect(task.errors).to be_empty
+  #   end
+  #   it 'タイトルが無ければ無効であること' do
+  #     # user = FactoryBot.create(:user)
 
-      task_without_title = build(:task, title: nil)
-      expect(task_without_title).to be_invalid
-      expect(task_without_title.errors[:title]).to include("can't be blank")
-    end
-    it 'ステータスが無ければ無効であること' do
-      # user = FactoryBot.create(:user)
+  #     task_without_title = build(:task, title: nil)
+  #     expect(task_without_title).to be_invalid
+  #     expect(task_without_title.errors[:title]).to include("can't be blank")
+  #   end
+  #   it 'ステータスが無ければ無効であること' do
+  #     # user = FactoryBot.create(:user)
 
-      task_without_status = build(:task, status: nil)
-      expect(task_without_status).to be_invalid
-      expect(task_without_status.errors[:status]).to include("can't be blank")
-    end
-    it 'タイトルが一意でなければ無効な状態であること' do
-      # user = FactoryBot.create(:user)
+  #     task_without_status = build(:task, status: nil)
+  #     expect(task_without_status).to be_invalid
+  #     expect(task_without_status.errors[:status]).to include("can't be blank")
+  #   end
+  #   it 'タイトルが一意でなければ無効な状態であること' do
+  #     # user = FactoryBot.create(:user)
 
-      task = create(:task)
-      task_with_duplicated_title = build(:task, title: task.title)
-      expect(task_with_duplicated_title).to be_invalid
-      expect(task_with_duplicated_title.errors[:title]).to include("has already been taken")
-    end
-    it 'タイトルが一意であれば有効であること' do
-      # user = FactoryBot.create(:user)
+  #     task = create(:task)
+  #     task_with_duplicated_title = build(:task, title: task.title)
+  #     expect(task_with_duplicated_title).to be_invalid
+  #     expect(task_with_duplicated_title.errors[:title]).to include("has already been taken")
+  #   end
+  #   it 'タイトルが一意であれば有効であること' do
+  #     # user = FactoryBot.create(:user)
 
-      task = create(:task)
-      task_with_another_title = build(:task, title: 'another_title')
-      expect(task_with_another_title).to be_valid
-      expect(task_with_another_title.errors).to be_empty
-    end
-  end
+  #     task = create(:task)
+  #     task_with_another_title = build(:task, title: 'another_title')
+  #     expect(task_with_another_title).to be_valid
+  #     expect(task_with_another_title.errors).to be_empty
+  #   end
+  # end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,7 +20,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.
@@ -30,6 +30,9 @@ rescue ActiveRecord::PendingMigrationError => e
   puts e.to_s.strip
   exit 1
 end
+
+require 'capybara/rspec'
+
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
@@ -61,6 +64,11 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+  config.include LoginModule
 
   config.include FactoryBot::Syntax::Methods
+
+  config.before(:each, type: :system) do
+    driven_by :selenium_chrome_headless
+  end
 end

--- a/spec/support/login_module.rb
+++ b/spec/support/login_module.rb
@@ -1,0 +1,8 @@
+module LoginModule
+  def login(user)
+    visit login_path
+    fill_in 'Email', with: user.email
+    fill_in 'Password', with: 'password'
+    click_button 'Login'
+  end
+end

--- a/spec/support/login_module.rb
+++ b/spec/support/login_module.rb
@@ -1,6 +1,7 @@
 module LoginModule
   def login(user)
-    visit login_path
+    visit root_path
+    click_link 'Login'
     fill_in 'Email', with: user.email
     fill_in 'Password', with: 'password'
     click_button 'Login'

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -80,6 +80,19 @@ RSpec.describe 'Tasks', type: :system do
         end
       end
     end
+
+    describe 'タスク削除' do
+      let!(:task) { create(:task, user: user) }
+
+      it 'タスクの削除が成功する' do
+        visit tasks_path
+        click_link 'Destroy'
+        expect(page.accept_confirm).to eq 'Are you sure?'
+        expect(page).to have_content 'Task was successfully destroyed'
+        expect(current_path).to eq tasks_path
+        expect(page).not_to have_content task.title
+      end
+    end
   end
 
   describe 'ログイン前' do

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -1,0 +1,89 @@
+require 'rails_helper'
+
+RSpec.describe 'Users', type: :system do
+  describe 'ログイン前' do
+    describe 'ユーザー新規登録' do
+      context 'フォームの入力値が正常' do
+        it 'ユーザーの新規作成が成功する' do
+          user = build(:user)
+          expect(user).to be_valid
+          # expect(user.errors).to be_empty
+        end
+      end
+      context 'メールアドレスが未入力' do
+        it 'ユーザーの新規作成が失敗する' do
+          user = build(:user, email: "")
+          expect(user).to be_invalid
+        end
+      end
+      context '登録済のメールアドレスを使用' do
+        it 'ユーザーの新規作成が失敗する' do
+          create(:user, email: "user@example.com")
+          invalid_user = build(:user, email: "user@example.com")
+          expect(invalid_user).to be_invalid
+        end
+      end
+    end
+
+    describe 'マイページ' do
+      context 'ログインしていない状態' do
+        it 'マイページへのアクセスが失敗する' do
+          visit root_path
+        end
+      end
+    end
+  end
+
+  describe 'ログイン後' do
+    before do
+      @user = create(:user, email: "sample@example.com" )
+      visit login_path
+      fill_in 'Email', with: "sample@example.com"
+      fill_in 'Password', with: "password"
+      click_button 'Login'
+    end
+    describe 'ユーザー編集' do
+      before do
+        visit edit_user_path(1)
+      end
+      context 'フォームの入力値が正常' do
+        it 'ユーザーの編集が成功する' do
+          click_button 'Update'
+          expect(@user.reload).to completed?
+        end
+      end
+      context 'メールアドレスが未入力' do
+        it 'ユーザーの編集が失敗する'
+      end
+      context '登録済のメールアドレスを使用' do
+        it 'ユーザーの編集が失敗する'
+      end
+      context '他ユーザーの編集ページにアクセス' do
+        it '編集ページへのアクセスが失敗する'
+      end
+    end
+
+    describe 'マイページ' do
+      context 'タスクを作成' do
+        it '新規作成したタスクが表示される'
+      end
+    end
+  end
+end
+
+RSpec.describe 'UserSessions', type: :system do
+  describe 'ログイン前' do
+    context 'フォームの入力値が正常' do
+      it 'ログイン処理が成功する'
+    end
+    context 'フォームが未入力' do
+      it 'ログイン処理が失敗する'
+    end
+  end
+
+  describe 'ログイン後' do
+    context 'ログアウトボタンをクリック' do
+      it 'ログアウト処理が成功する'
+    end
+  end
+end

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -46,6 +46,8 @@ RSpec.describe 'Tasks', type: :system do
     end
     describe 'タスクの編集' do
       let!(:task) { create(:task, user: user) }
+      let(:other_task) { create(:task, user: user) }
+
       context 'フォームの入力値が正常' do
         it 'タスクの編集が成功する' do
           visit edit_task_path(task)
@@ -64,6 +66,17 @@ RSpec.describe 'Tasks', type: :system do
           click_button 'Update Task'
           expect(current_path).to eq '/tasks/1'
           expect(page).to have_content "Title can't be blank"
+        end
+      end
+      context '登録済のタイトルを入力' do
+        it 'タスクの編集が失敗する' do
+          visit edit_task_path(task)
+          fill_in 'Title', with: other_task.title
+          select :todo, from: 'Status'
+          click_button 'Update Task'
+          expect(page).to have_content '1 error prohibited this task from being saved'
+          expect(page).to have_content "Title has already been taken"
+          expect(current_path).to eq task_path(task)
         end
       end
     end

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -68,4 +68,42 @@ RSpec.describe 'Tasks', type: :system do
       end
     end
   end
+
+  describe 'ログイン前' do
+    describe 'ページ遷移確認' do
+      context 'タスクの新規登録ページにアクセス' do
+        it '新規登録ページへのアクセスが失敗する' do
+          visit new_task_path
+          expect(page).to have_content('Login required')
+          expect(current_path).to eq login_path
+        end
+      end
+      context 'タスクの編集ページにアクセス' do
+        it '編集ページへのアクセスが失敗する' do
+          visit edit_task_path(task)
+          expect(page).to have_content('Login required')
+          expect(current_path).to eq login_path
+        end
+      end
+
+      context 'タスクの詳細ページにアクセス' do
+        it 'タスクの詳細情報が表示される' do
+          visit task_path(task)
+          expect(page).to have_content task.title
+          expect(current_path).to eq task_path(task)
+        end
+      end
+
+      context 'タスクの一覧ページにアクセス' do
+        it 'すべてのユーザーのタスク情報が表示される' do
+          task_list = create_list(:task, 3)
+          visit tasks_path
+          expect(page).to have_content task_list[0].title
+          expect(page).to have_content task_list[1].title
+          expect(page).to have_content task_list[2].title
+          expect(current_path).to eq tasks_path
+        end
+      end
+    end
+  end
 end

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -3,8 +3,10 @@ require 'rails_helper'
 RSpec.describe 'Tasks', type: :system do
   let(:user) { create(:user) }
   let(:task) { create(:task) }
+
   describe 'ログイン後' do
     before { login(user) }
+
     describe 'タスクの新規作成' do
       context 'フォームの入力値が正常' do
         it 'タスクの新規作成が成功する' do
@@ -32,12 +34,10 @@ RSpec.describe 'Tasks', type: :system do
       end
       context '登録済みのタイトルを入力' do
         it 'タスクの新規作成が失敗する' do
-          create(:task, title: 'title')
+          other_task = create(:task)
           click_link 'New Task'
-          fill_in 'Title', with: "title"
+          fill_in 'Title', with: other_task.title
           fill_in 'Content', with: "content"
-          select 'doing', from: 'Status'
-          fill_in 'Deadline', with: 1.week.from_now
           click_button 'Create Task'
           expect(current_path).to eq tasks_path
           expect(page).to have_content "Title has already been taken"

--- a/spec/system/user_sessions_spec.rb
+++ b/spec/system/user_sessions_spec.rb
@@ -30,8 +30,7 @@ RSpec.describe 'UserSessions', type: :system do
     before { login(user) }
     context 'ログアウトボタンをクリック' do
       it 'ログアウト処理が成功する' do
-        visit root_path
-        click_button 'Logout'
+        click_link 'Logout'
         expect(current_path).to eq root_path
         expect(page).to have_content "Logged out"
       end

--- a/spec/system/user_sessions_spec.rb
+++ b/spec/system/user_sessions_spec.rb
@@ -2,17 +2,39 @@ require 'rails_helper'
 
 RSpec.describe 'UserSessions', type: :system do
   describe 'ログイン前' do
+    let(:user) { create(:user) }
     context 'フォームの入力値が正常' do
-      it 'ログイン処理が成功する'
+      it 'ログイン処理が成功する' do
+        visit login_path
+        fill_in 'Email', with: user.email
+        fill_in 'Password', with: 'password'
+        click_button 'Login'
+        expect(current_path).to eq root_path
+        expect(page).to have_content "Login successful"
+      end
     end
     context 'フォームが未入力' do
-      it 'ログイン処理が失敗する'
+      it 'ログイン処理が失敗する' do
+        visit login_path
+        fill_in 'Email', with: nil
+        fill_in 'Password', with: nil
+        click_button 'Login'
+        expect(current_path).to eq login_path
+        expect(page).to have_content "Login failed"
+      end
     end
   end
 
   describe 'ログイン後' do
+    let(:user) { create(:user) }
+    before { login(user) }
     context 'ログアウトボタンをクリック' do
-      it 'ログアウト処理が成功する'
+      it 'ログアウト処理が成功する' do
+        visit root_path
+        click_button 'Logout'
+        expect(current_path).to eq root_path
+        expect(page).to have_content "Logged out"
+      end
     end
   end
 end

--- a/spec/system/user_sessions_spec.rb
+++ b/spec/system/user_sessions_spec.rb
@@ -1,8 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe 'UserSessions', type: :system do
+  let(:user) { create(:user) }
+
   describe 'ログイン前' do
-    let(:user) { create(:user) }
     context 'フォームの入力値が正常' do
       it 'ログイン処理が成功する' do
         visit login_path
@@ -26,7 +27,6 @@ RSpec.describe 'UserSessions', type: :system do
   end
 
   describe 'ログイン後' do
-    let(:user) { create(:user) }
     before { login(user) }
     context 'ログアウトボタンをクリック' do
       it 'ログアウト処理が成功する' do

--- a/spec/system/user_sessions_spec.rb
+++ b/spec/system/user_sessions_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe 'UserSessions', type: :system do
+  describe 'ログイン前' do
+    context 'フォームの入力値が正常' do
+      it 'ログイン処理が成功する'
+    end
+    context 'フォームが未入力' do
+      it 'ログイン処理が失敗する'
+    end
+  end
+
+  describe 'ログイン後' do
+    context 'ログアウトボタンをクリック' do
+      it 'ログアウト処理が成功する'
+    end
+  end
+end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -67,8 +67,7 @@ RSpec.describe 'Users', type: :system do
       context 'メールアドレスが未入力' do
         it 'ユーザーの編集が失敗する' do
           visit edit_user_path(user)
-          fill_in 'Email', with: user.email
-          fill_in 'Password', with: "password"
+          fill_in 'Email', with: nil
           fill_in 'Password confirmation', with: "password"
           click_button 'Update'
           expect(current_path).to eq user_path(user)
@@ -98,13 +97,13 @@ RSpec.describe 'Users', type: :system do
       context 'タスクを作成' do
         it '新規作成したタスクが表示される' do
           visit tasks_path
-          click_button 'New Task'
+          click_link 'New Task'
           fill_in 'Title', with: "title"
           fill_in 'Content', with: "content"
-          fill_in 'Status', with: "todo"
+          select 'doing', from: 'Status'
           fill_in 'Deadline', with: 1.week.from_now
           click_button 'Create Task'
-          expect(current_path).to eq task_path(task)
+          expect(current_path).to eq '/tasks/1'
           expect(page).to have_content "Task was successfully created."
         end
       end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -1,0 +1,113 @@
+require 'rails_helper'
+
+RSpec.describe 'Users', type: :system do
+  let(:user) { create(:user) }
+  let(:second_user) { create(:user) }
+  describe 'ログイン前' do
+    describe 'ユーザー新規登録' do
+      context 'フォームの入力値が正常' do
+        it 'ユーザーの新規作成が成功する' do
+          visit sign_up_path
+          fill_in 'Email', with: "sample@example.com"
+          fill_in 'Password', with: "password"
+          fill_in 'Password confirmation', with: "password"
+          click_button 'SignUp'
+          expect(current_path).to eq login_path
+          expect(page).to have_content 'User was successfully created.'
+        end
+      end
+      context 'メールアドレスが未入力' do
+        it 'ユーザーの新規作成が失敗する' do
+          visit sign_up_path
+          fill_in 'Email', with: ""
+          fill_in 'Password', with: "password"
+          fill_in 'Password confirmation', with: "password"
+          click_button 'SignUp'
+          expect(current_path).to eq users_path
+          expect(page).to have_content "Email can't be blank"
+        end
+      end
+      context '登録済のメールアドレスを使用' do
+        it 'ユーザーの新規作成が失敗する' do
+          visit sign_up_path
+          fill_in 'Email', with: user.email
+          fill_in 'Password', with: "password"
+          fill_in 'Password confirmation', with: "password"
+          click_button 'SignUp'
+          expect(current_path).to eq users_path
+          expect(page).to have_content "Email has already been taken"
+        end
+      end
+      describe 'マイページ' do
+        context 'ログインしていない状態' do
+          it 'マイページへのアクセスが失敗する' do
+            visit user_path(user)
+            expect(current_path).to eq login_path
+            expect(page).to have_content "Login required"
+          end
+        end
+      end
+    end
+  end
+
+  describe 'ログイン後' do
+    before { login(user) } 
+    describe 'ユーザー編集' do
+      context 'フォームの入力値が正常' do
+        it 'ユーザーの編集が成功する' do
+          visit edit_user_path(user)
+          fill_in 'Email', with: user.email
+          fill_in 'Password', with: "password"
+          fill_in 'Password confirmation', with: "password"
+          click_button 'Update'
+          expect(current_path).to eq user_path(user)
+          expect(page).to have_content "User was successfully updated."
+        end
+      end
+      context 'メールアドレスが未入力' do
+        it 'ユーザーの編集が失敗する' do
+          visit edit_user_path(user)
+          fill_in 'Email', with: user.email
+          fill_in 'Password', with: "password"
+          fill_in 'Password confirmation', with: "password"
+          click_button 'Update'
+          expect(current_path).to eq user_path(user)
+          expect(page).to have_content "Email can't be blank"
+        end
+      end
+      context '登録済のメールアドレスを使用' do
+        it 'ユーザーの編集が失敗する' do
+          visit edit_user_path(user)
+          fill_in 'Email', with: second_user.email
+          fill_in 'Password', with: "password"
+          fill_in 'Password confirmation', with: "password"
+          click_button 'Update'
+          expect(current_path).to eq user_path(user)
+          expect(page).to have_content "Email has already been taken"
+        end
+      end
+      context '他ユーザーの編集ページにアクセス' do
+        it '編集ページへのアクセスが失敗する' do
+          visit edit_user_path(second_user)
+          expect(current_path).to eq user_path(user)
+          expect(page).to have_content "Forbidden access."
+        end
+      end
+    end
+    describe 'マイページ' do
+      context 'タスクを作成' do
+        it '新規作成したタスクが表示される' do
+          visit tasks_path
+          click_button 'New Task'
+          fill_in 'Title', with: "title"
+          fill_in 'Content', with: "content"
+          fill_in 'Status', with: "todo"
+          fill_in 'Deadline', with: 1.week.from_now
+          click_button 'Create Task'
+          expect(current_path).to eq task_path(task)
+          expect(page).to have_content "Task was successfully created."
+        end
+      end
+    end
+  end
+end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -96,15 +96,14 @@ RSpec.describe 'Users', type: :system do
     describe 'マイページ' do
       context 'タスクを作成' do
         it '新規作成したタスクが表示される' do
-          visit tasks_path
-          click_link 'New Task'
-          fill_in 'Title', with: "title"
-          fill_in 'Content', with: "content"
-          select 'doing', from: 'Status'
-          fill_in 'Deadline', with: 1.week.from_now
-          click_button 'Create Task'
-          expect(current_path).to eq '/tasks/1'
-          expect(page).to have_content "Task was successfully created."
+          create(:task, title: 'test_title', status: :doing, user: user)
+          visit user_path(user)
+          expect(page).to have_content('You have 1 task.')
+          expect(page).to have_content('test_title')
+          expect(page).to have_content('doing')
+          expect(page).to have_link('Show')
+          expect(page).to have_link('Edit')
+          expect(page).to have_link('Destroy')
         end
       end
     end


### PR DESCRIPTION
gem2種類を追加。
```
group :test do
  gem 'capybara'
  gem 'webdrivers'
end
```

spec下にsupportディレクトリを作成し、ログインを行うモジュールを作成。
rails.helperの一部分をコメントアウト、モジュールの追記で有効化。
```
Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
config.include LoginModule
```

ブラウザの指定を一元管理
```
config.before(:each, type: :system) do
    driven_by :selenium_chrome_headless
  end
```

[![Image from Gyazo](https://i.gyazo.com/3ba384d33186cabad46b4cced34b5caf.png)](https://gyazo.com/3ba384d33186cabad46b4cced34b5caf)